### PR TITLE
feat: deduplicate review feedback using existing PR comments

### DIFF
--- a/src/clients/github.py
+++ b/src/clients/github.py
@@ -407,41 +407,46 @@ class GitHubClient:
         )
         return resp.json()
 
+    async def _fetch_paginated(
+        self, path: str, installation_id: int, max_pages: int = 3,
+    ) -> list[dict]:
+        """Fetch a paginated list endpoint, returning up to max_pages of results."""
+        all_items: list[dict] = []
+        per_page = 100
+        for page in range(1, max_pages + 1):
+            resp = await self._request(
+                "GET", path, installation_id,
+                params={"per_page": per_page, "page": page},
+            )
+            items = resp.json()
+            all_items.extend(items)
+            if len(items) < per_page:
+                break
+        return all_items
+
     async def get_pr_comments(
         self, owner: str, repo: str, pr_number: int, installation_id: int,
     ) -> list[dict]:
         """Fetch inline review comments on a PR."""
-        resp = await self._request(
-            "GET",
-            f"/repos/{owner}/{repo}/pulls/{pr_number}/comments",
-            installation_id,
-            params={"per_page": 100},
+        return await self._fetch_paginated(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/comments", installation_id,
         )
-        return resp.json()
 
     async def get_pr_reviews(
         self, owner: str, repo: str, pr_number: int, installation_id: int,
     ) -> list[dict]:
         """Fetch top-level reviews on a PR."""
-        resp = await self._request(
-            "GET",
-            f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
-            installation_id,
-            params={"per_page": 100},
+        return await self._fetch_paginated(
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews", installation_id,
         )
-        return resp.json()
 
     async def get_issue_comments(
         self, owner: str, repo: str, issue_number: int, installation_id: int,
     ) -> list[dict]:
         """Fetch issue-level comments on a PR/issue."""
-        resp = await self._request(
-            "GET",
-            f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
-            installation_id,
-            params={"per_page": 100},
+        return await self._fetch_paginated(
+            f"/repos/{owner}/{repo}/issues/{issue_number}/comments", installation_id,
         )
-        return resp.json()
 
     async def get_commits(
         self,

--- a/src/clients/github.py
+++ b/src/clients/github.py
@@ -407,6 +407,42 @@ class GitHubClient:
         )
         return resp.json()
 
+    async def get_pr_comments(
+        self, owner: str, repo: str, pr_number: int, installation_id: int,
+    ) -> list[dict]:
+        """Fetch inline review comments on a PR."""
+        resp = await self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/comments",
+            installation_id,
+            params={"per_page": 100},
+        )
+        return resp.json()
+
+    async def get_pr_reviews(
+        self, owner: str, repo: str, pr_number: int, installation_id: int,
+    ) -> list[dict]:
+        """Fetch top-level reviews on a PR."""
+        resp = await self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+            installation_id,
+            params={"per_page": 100},
+        )
+        return resp.json()
+
+    async def get_issue_comments(
+        self, owner: str, repo: str, issue_number: int, installation_id: int,
+    ) -> list[dict]:
+        """Fetch issue-level comments on a PR/issue."""
+        resp = await self._request(
+            "GET",
+            f"/repos/{owner}/{repo}/issues/{issue_number}/comments",
+            installation_id,
+            params={"per_page": 100},
+        )
+        return resp.json()
+
     async def get_commits(
         self,
         owner: str,

--- a/src/gemini_client.py
+++ b/src/gemini_client.py
@@ -110,6 +110,7 @@ class GeminiClient:
         pr_title: str,
         pr_body: str,
         styleguide: str,
+        existing_feedback: str = "",
     ) -> dict:
         """Generate a structured code review with inline comments.
 
@@ -165,6 +166,17 @@ Each comment body MUST follow this structure:
 - Write as many comments as needed to cover all significant issues — do not limit yourself
 - Focus on: security issues, bugs, code quality problems, and praise for decent code
 - Every comment must be in character as Ricky
+- DO NOT repeat any feedback already given in the "Existing review comments" section
+- If Ricky or Julian already flagged an issue, skip it entirely — focus on NEW issues only
+- If there is nothing new to say, return an empty comments list with a short summary
+"""
+
+        existing_section = ""
+        if existing_feedback:
+            existing_section = f"""
+**Existing review comments on this PR (DO NOT repeat these points):**
+{existing_feedback}
+
 """
 
         user_prompt = f"""Review this pull request and provide inline comments on specific lines.
@@ -173,8 +185,7 @@ Each comment body MUST follow this structure:
 
 **Description:**
 {pr_body}
-
-**Changed lines by file:**
+{existing_section}**Changed lines by file:**
 {structured_diff}
 
 **Full diff for additional context:**

--- a/src/tools/review.py
+++ b/src/tools/review.py
@@ -1,5 +1,6 @@
 """PR review tool — the core code review functionality."""
 
+import asyncio
 import logging
 import re
 
@@ -91,14 +92,16 @@ async def review_pr(ctx: WebhookContext) -> None:
         owner, repo, ".gemini/styleguide.md", ctx.pr.head_ref, ctx.installation_id,
     ) or ""
 
-    # Fetch existing comments to avoid repeating feedback
+    # Fetch existing comments in parallel to avoid repeating feedback
     try:
-        pr_comments = await gh.get_pr_comments(owner, repo, pr_number, ctx.installation_id)
-        reviews = await gh.get_pr_reviews(owner, repo, pr_number, ctx.installation_id)
-        issue_comments = await gh.get_issue_comments(owner, repo, pr_number, ctx.installation_id)
+        pr_comments, reviews, issue_comments = await asyncio.gather(
+            gh.get_pr_comments(owner, repo, pr_number, ctx.installation_id),
+            gh.get_pr_reviews(owner, repo, pr_number, ctx.installation_id),
+            gh.get_issue_comments(owner, repo, pr_number, ctx.installation_id),
+        )
         existing_feedback = _format_existing_comments(pr_comments, reviews, issue_comments)
     except Exception:
-        log.warning("Failed to fetch existing comments, proceeding without")
+        log.warning("Failed to fetch existing comments, proceeding without", exc_info=True)
         existing_feedback = ""
 
     review = await gemini.generate_review(

--- a/src/tools/review.py
+++ b/src/tools/review.py
@@ -13,6 +13,48 @@ log = logging.getLogger(__name__)
 
 MAX_DIFF_CHARS = 100_000
 
+_MAX_COMMENT_LEN = 200
+_MAX_TOTAL_LEN = 4000
+
+
+def _format_existing_comments(
+    pr_comments: list[dict],
+    reviews: list[dict],
+    issue_comments: list[dict],
+) -> str:
+    """Format existing PR feedback into a summary for the Gemini prompt."""
+    lines: list[str] = []
+
+    for c in pr_comments:
+        login = c.get("user", {}).get("login", "unknown")
+        tag = login.replace("[bot]", "") if login.endswith("[bot]") else "human"
+        path = c.get("path", "")
+        line_num = c.get("line") or c.get("original_line") or "?"
+        body = (c.get("body") or "")[:_MAX_COMMENT_LEN]
+        lines.append(f"[{tag}] {path}:{line_num} — {body}")
+
+    for r in reviews:
+        body = (r.get("body") or "").strip()
+        if not body:
+            continue
+        login = r.get("user", {}).get("login", "unknown")
+        tag = login.replace("[bot]", "") if login.endswith("[bot]") else "human"
+        lines.append(f"[{tag} review] {body[:_MAX_COMMENT_LEN]}")
+
+    for c in issue_comments:
+        login = c.get("user", {}).get("login", "unknown")
+        tag = login.replace("[bot]", "") if login.endswith("[bot]") else "human"
+        body = (c.get("body") or "")[:_MAX_COMMENT_LEN]
+        lines.append(f"[{tag} comment] {body}")
+
+    if not lines:
+        return ""
+
+    result = "\n".join(lines)
+    if len(result) > _MAX_TOTAL_LEN:
+        result = result[:_MAX_TOTAL_LEN] + "\n...(truncated)"
+    return result
+
 
 @tool(
     "review",
@@ -49,12 +91,23 @@ async def review_pr(ctx: WebhookContext) -> None:
         owner, repo, ".gemini/styleguide.md", ctx.pr.head_ref, ctx.installation_id,
     ) or ""
 
+    # Fetch existing comments to avoid repeating feedback
+    try:
+        pr_comments = await gh.get_pr_comments(owner, repo, pr_number, ctx.installation_id)
+        reviews = await gh.get_pr_reviews(owner, repo, pr_number, ctx.installation_id)
+        issue_comments = await gh.get_issue_comments(owner, repo, pr_number, ctx.installation_id)
+        existing_feedback = _format_existing_comments(pr_comments, reviews, issue_comments)
+    except Exception:
+        log.warning("Failed to fetch existing comments, proceeding without")
+        existing_feedback = ""
+
     review = await gemini.generate_review(
         diff=diff,
         structured_diff=structured_diff,
         pr_title=ctx.pr.title,
         pr_body=ctx.pr.body,
         styleguide=styleguide,
+        existing_feedback=existing_feedback,
     )
 
     summary = review.get("summary", "")


### PR DESCRIPTION
## Summary
- Adds `get_pr_comments`, `get_pr_reviews`, `get_issue_comments` to the GitHub client to fetch all existing feedback on a PR
- Formats prior comments into a concise summary and injects it into the Gemini prompt so Ricky skips points already made
- On `synchronize` events (new commits pushed), Ricky now avoids repeating feedback from Ricky, Julian, or human reviewers

## Details
- Comment fetching is wrapped in try/except since Ricky's `_request` raises on non-200 — reviews are never blocked
- First-time reviews (no prior comments) are unaffected — `existing_feedback` defaults to `""` and the prompt is unchanged
- Output is bounded: `per_page=100`, body truncated to 200 chars per comment, total capped at 4000 chars

## Test plan
- [ ] Verify import: `python -c "from src.clients.github import GitHubClient"`
- [ ] Push a commit to a PR that already has bot comments — verify Ricky doesn't repeat the same issues
- [ ] Open a fresh PR — verify first-time review works normally with no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)